### PR TITLE
Fix: Use relative paths to allow generic mocha execution 1.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.3
+- fix: refactor tests so they can run alongside all other HF/API library tests
+
 # 1.0.2
 - docs: create/update
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # 1.0.3
-- fix: refactor tests so they can run alongside all other HF/API library tests
+- fix: use relative paths to allow generic mocha execution
 
 # 1.0.2
 - docs: create/update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-plugin-seq-audit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatic sequence number verification plugin for the Bitfinex Node API",
   "engines": {
     "node": ">=7"

--- a/test/ws/close.js
+++ b/test/ws/close.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onWSClose = require('ws/close')
+const onWSClose = require('../../lib/ws/close')
 
 describe('ws:close', () => {
   it('resets sequence numbers', () => {

--- a/test/ws/message.js
+++ b/test/ws/message.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onWSMessage = require('ws/message')
+const onWSMessage = require('../../lib/ws/message')
 
 describe('ws:message', () => {
   it('emits error on invalid public seq #', (done) => {

--- a/test/ws/open.js
+++ b/test/ws/open.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const { Config } = require('bfx-api-node-core')
-const onWSOpen = require('ws/open')
+const onWSOpen = require('../../lib/ws/open')
 
 describe('ws:open', () => {
   it('enables sequencing flag', (done) => {


### PR DESCRIPTION
### Fixes:
- [x] Use relative paths in tests

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
